### PR TITLE
Put key last

### DIFF
--- a/src/variant.ts
+++ b/src/variant.ts
@@ -106,13 +106,13 @@ export function variantFactory<K extends string>(key: K) {
             const returned = (func ?? identityFunc)(...args);
             if (isPromise(returned)) {
                 return returned.then(result => ({
-                    [key]: tag,
                     ...result,
+                    [key]: tag,
                 }))
             } else {
                 return {
-                    [key]: tag,
                     ...returned,
+                    [key]: tag,
                 }
             }
         };


### PR DESCRIPTION
We've been using `variant` v2 in a green(-ish)field project at my workplace, and it's been a pleasure so far! However, we've encountered one slight annoyance due to a particular data pattern in our application.

We have what amounts to a multi-page form, which will have some data at the end, say:
```typescript
type FormData = {
  fieldA: string;
  fieldB: number;
  fieldC: {str1: string, str2: string};
  ...
}
``` 
with each field having its own page. To ensure that we're adding data in order, we constructed a variant module, with fields that are partially constructed versions of the end result:
```typescript
const FormVariant = {
  stateA: {};
  stateB: fields<Pick<FormData, 'fieldA'>>();
  stateC: fields<Pick<FormData, 'fieldA' | 'fieldB'>>();
  ...
  complete: fields<FormData>();
};
```

The problem comes in though the transition from one state to another. Since each state is the previous one + some more data, we initially tried to do this for an update:

```typescript
const newState = FormVariant.stateC({...oldState, fieldB: b});
```

Hovering over `newState` shows that this should be a `stateC` variant, as we'd expect. At _runtime_, however, the `type` field is _not_ `stateC`, but still `stateB`, which makes us think the update did nothing at all.

Poking through the code, I found that `[key]: tag` came _before_ the result spread, rather than after, which presumably causes the above behavior.