### PR TITLE
Creator output hinting

### DIFF
--- a/src/augment.ts
+++ b/src/augment.ts
@@ -27,7 +27,7 @@ export function augment<T extends RawVariant, F extends (x: VariantOf<VariantRec
         let inputFunc = variantDefinition[key] as Func
 
         let returnFunc = isVariantCreator(inputFunc)
-            ? variation(inputFunc.type, (...args: any[]) => {
+            ? variation(inputFunc.output.type, (...args: any[]) => {
                 let result = inputFunc(...args);
                 return {
                     ...f(result),

--- a/src/generic.ts
+++ b/src/generic.ts
@@ -1,6 +1,6 @@
-import {flagsImpl, Matrix} from './flags';
-import {Func, TypesOf, Outputs, PatchObjectOrPromise, RawVariant, Stringable, SumType, TypeNames, VariantModule, VariantOf} from './precepts';
-import {variantImpl, VariantRecord} from './variant';
+import {flagsImpl} from './flags';
+import {Func, TypesOf, Outputs, PatchObjectOrPromise, RawVariant, Stringable, TypeNames, VariantOf} from './precepts';
+import {variantImpl} from './variant';
 
 type primitive = number | string | symbol | boolean | bigint;
 

--- a/src/isOfVariant.ts
+++ b/src/isOfVariant.ts
@@ -42,11 +42,11 @@ export function isOfVariantImpl<K extends string>(key: K): IsOfVariantFunc<K> {
             const [variant] = args;
 
             return (instance: {} | null | undefined) => instance != undefined
-                && Object.values(variant).some(vc => vc.type === (instance as Record<K, string>)[key]);
+                && Object.values(variant).some(vc => vc.output.type === (instance as Record<K, string>)[key]);
         } else if (args.length === 2) {
             const [instance, variant] = args;
             return instance != undefined
-                && Object.values(variant).some(vc => vc.type === (instance as Record<K, string>)[key]);
+                && Object.values(variant).some(vc => vc.output.type === (instance as Record<K, string>)[key]);
         }
         return false;
     }

--- a/src/isType.ts
+++ b/src/isType.ts
@@ -30,12 +30,12 @@ export function isTypeImpl<K extends string>(key: K): IsTypeFunc<K> {
         if (instanceOrType != undefined) {
             if (typeof instanceOrType === 'function' || typeof instanceOrType === 'string') {
                 const typeArg = instanceOrType as T;
-                const typeStr = typeof typeArg === 'string' ? typeArg : (typeArg as VariantCreator<string, any, K>).type;
+                const typeStr = typeof typeArg === 'string' ? typeArg : (typeArg as VariantCreator<string, any, K>).output.type;
                 return <O extends Record<K, string>>(o: O): o is Extract<O, Record<K, TypeStr<T, K>>> => isType(o, typeStr);
             } else {
                 const instance = instanceOrType as O;
 
-                const typeStr = typeof type === 'string' ? type : (type as VariantCreator<string, any, K>).type;
+                const typeStr = typeof type === 'string' ? type : (type as VariantCreator<string, any, K>).output.type;
                 return instance != undefined && (instance as Record<K, string>)[key ?? 'type'] === typeStr;
             }
         } else {

--- a/src/match.spec.ts
+++ b/src/match.spec.ts
@@ -1,9 +1,8 @@
-import {fields, match, payload, scoped, TypeNames, VariantOf, variation} from '.';
+import {fields, match, payload, scoped, TypeNames, VariantOf} from '.';
 import {lookup, ofLiteral, otherwise, partial, prematch, variant} from './type';
 import {typeMap} from './typeCatalog';
 import {constant, just, unpack} from './match.tools';
 import {Animal, CapsAnimal, sample} from './__test__/animal';
-import {catalog} from './catalog';
 
 
 test('match (basic)', () => {
@@ -123,9 +122,9 @@ test('caps animal', () => {
     const cat = CapsAnimal.cat({name: 'Steve', furnitureDamaged: 0}) as CapsAnimal;
     
     match(cat, {
-        [CapsAnimal.cat.type]: just(5),
-        [CapsAnimal.dog.type]: just(4),
-        [CapsAnimal.snake.type]: just(4),
+        [CapsAnimal.cat.output.type]: just(5),
+        [CapsAnimal.dog.output.type]: just(4),
+        [CapsAnimal.snake.output.type]: just(4),
     });
 })
 
@@ -167,7 +166,7 @@ test('scoped match', () => {
     const cat = Animal2.Cat({name: 'Perseus'});
 
     const rating = (animal: Animal2) => match(animal, partial({
-        [Animal2.Cat.type]: c => c.name,
+        [Animal2.Cat.output.type]: c => c.name,
         default: just('yo'),
     }))
 

--- a/src/match.ts
+++ b/src/match.ts
@@ -245,15 +245,15 @@ export function matchImpl<K extends string>(key: K): MatchFuncs<K> {
                 : handlerParam
             ;
 
-            const tType = instance == undefined 
+            const tType = instanceOrCreator == undefined
                 ? undefined
                 : isVariantCreator(instanceOrCreator)
                 ? instanceOrCreator.output.type as keyof typeof handler
                 : (instanceOrCreator as T)[key]
             ;
 
-            if (instance != undefined && tType !== undefined && tType in handler) {
-                return handler[tType]?.(instance as any);
+            if (instanceOrCreator != undefined && tType !== undefined && tType in handler) {
+                return handler[tType]?.(instanceOrCreator as any);
             } else if (DEFAULT_KEY in handler) {
                 return handler[DEFAULT_KEY]?.(instanceOrCreator as any);
             }

--- a/src/matcher.spec.ts
+++ b/src/matcher.spec.ts
@@ -1,5 +1,5 @@
-import {lookup, match, matcher, ofLiteral, types} from './type';
-import {constant, just} from './match.tools';
+import {match, matcher, ofLiteral, types} from './type';
+import {constant} from './match.tools';
 import {Animal, sample} from './__test__/animal';
 
 test('matcher creation', () => {
@@ -153,7 +153,7 @@ test('matcher (when-complete)', () => {
     const getFeature = (a: Animal) => matcher(a)
         .with({
             cat: c => c.furnitureDamaged,
-            [Animal.dog.type]: d => d.favoriteBall,
+            [Animal.dog.output.type]: d => d.favoriteBall,
             snake: s => s.pattern,
         })
         .complete();
@@ -185,8 +185,8 @@ test('matcher (ofLiteral)', () => {
             snake: 3,
         });
 
-    expect(rate(Animal.cat.type)).toBe(1);
-    expect(rate(Animal.dog.type)).toBe(2);
+    expect(rate(Animal.cat.output.type)).toBe(1);
+    expect(rate(Animal.dog.output.type)).toBe(2);
 })
 declare var animal: Animal;
 
@@ -222,8 +222,8 @@ test('matcher (of literal directly)', () => {
             snake: 3,
         });
 
-    expect(rate(Animal.cat.type)).toBe(1);
-    expect(rate(Animal.dog.type)).toBe(2);
+    expect(rate(Animal.cat.output.type)).toBe(1);
+    expect(rate(Animal.dog.output.type)).toBe(2);
 })
 
 test('match enum directly', () => {

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -1,7 +1,7 @@
 import {Handler} from './match';
 import {just} from './match.tools';
 import {Func, Limited, Splay, VariantCreator, VariantError} from './precepts';
-import {Identity, TypeStr} from './util';
+import {TypeStr} from './util';
 import {isVariantCreator} from './variant';
 
 /**
@@ -266,7 +266,7 @@ export class Matcher<
             // 2 param case
             const list = Array.isArray(variations) ? variations : [variations];
             const newCases = list.reduce((acc, cur) => {
-                const type = typeof cur === 'string' ? cur : isVariantCreator(cur) ? cur.type : undefined;
+                const type = typeof cur === 'string' ? cur : isVariantCreator(cur) ? cur.output.type : undefined;
     
                 return type != undefined ? (
                     {...acc, [type]: handler}

--- a/src/precepts.ts
+++ b/src/precepts.ts
@@ -38,14 +38,16 @@ export type PatchObjectOrPromise<
  * The type marking metadata. 
  */
 export type Outputs<K, T> = {
-    /**
-     * Discriminant property key
-     */
-    key: K
-    /**
-     * The type of object created by this function.
-     */
-    type: T
+    output: {
+      /**
+       * Discriminant property key
+       */
+      key: K
+      /**
+       * The type of object created by this function.
+       */
+      type: T
+    }
 };
 
 /**
@@ -77,7 +79,7 @@ export type VariantCreator<
  */
 export type CreatorOutput<VC extends VariantCreator<string, Func, string>> = 
     ReturnType<VC> extends PromiseLike<infer R>
-        ? R extends Record<VC['key'], string> ? R : never
+        ? R extends Record<VC['output']['key'], string> ? R : never
         : ReturnType<VC>
 ;
 
@@ -103,7 +105,7 @@ export type Func = (...args: any[]) => any;
  * This type creates a mapping from the name/label to the type.
  */
 export type TypeMap<T extends VariantModule<string>> = {
-    [P in keyof T]: T[P]['type'];
+    [P in keyof T]: T[P]['output']['type'];
 }
 
 /**
@@ -113,7 +115,7 @@ export type GetTypeLabel<
     T extends VariantModule<string>,
     Key extends TypesOf<T>
 > = {
-    [P in keyof T]: T[P]['type'] extends Key ? P : never
+    [P in keyof T]: T[P]['output']['type'] extends Key ? P : never
 }[keyof T];
 
 /**
@@ -164,7 +166,7 @@ export type SumType<T extends VariantModule<string>> = Identity<VariantTypeSprea
 export type VariantOf<
     T extends VariantModule<string>,
     TType = undefined,
-> = TType extends undefined ? SumType<T> : TType extends TypesOf<T> ? Extract<SumType<T>, Record<T[keyof T]['key'], TType>> : SumType<T>;
+> = TType extends undefined ? SumType<T> : TType extends TypesOf<T> ? Extract<SumType<T>, Record<T[keyof T]['output']['key'], TType>> : SumType<T>;
 
 /**
  * The input type for `variant`/`variantModule`. 

--- a/src/remote.spec.ts
+++ b/src/remote.spec.ts
@@ -63,6 +63,6 @@ test('order index', () => {
 })
 
 test('get', () => {
-    expect(rank.get(0).type).toBe('dog');
+    expect(rank.get(0).output.type).toBe('dog');
     expect(rank.types[0]).toBe('dog');
 })

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -66,7 +66,7 @@ type SequenceInputType<T extends SequenceInput<K>, K extends string> =
     T extends string
         ? T
         : T extends VariantCreator<string, Func, K>
-            ? T['type']
+            ? T['output']['type']
             : T extends Record<K, string>
                 ? T[K]
                 : never
@@ -160,7 +160,7 @@ export function remoteImpl<K extends string>(key: K): RemoteFuncs<K> {
         if (typeof input === 'string') {
             return input as U;
         } else if (typeof input === 'function') {
-            return (input as VariantCreator<string, Func, K>).type as U;
+            return (input as VariantCreator<string, Func, K>).output.type as U;
         } else {
             return (input as Record<K, string>)[key] as U;
         }

--- a/src/typeCatalog.ts
+++ b/src/typeCatalog.ts
@@ -25,7 +25,7 @@ export function typeCatalog<T extends VariantModule<string>>(variant: T) {
     return Object.values(variant).reduce((result, vc) => {
         return {
             ...result,
-            [vc.type]: vc.type,
+            [vc.output.type]: vc.output.type,
         }
     }, {} as Identity<TypeCatalog<T>>)
 }
@@ -56,7 +56,7 @@ export function typeMap<T extends VariantModule<string>>(variant: T) {
     return Object.keys(variant).reduce((result, key) => {
         return {
             ...result,
-            [key]: variant[key].type,
+            [key]: variant[key].output.type,
         }
     }, {} as Identity<TypeMap<T>>)
 }

--- a/src/types.spec.ts
+++ b/src/types.spec.ts
@@ -5,9 +5,9 @@ test('types (on variant)', () => {
     const animalTypes = types(Animal);
 
     expect(animalTypes.length).toBe(3);
-    expect(animalTypes.includes(Animal.cat.type)).toBe(true);
-    expect(animalTypes.includes(Animal.dog.type)).toBe(true);
-    expect(animalTypes.includes(Animal.snake.type)).toBe(true);
+    expect(animalTypes.includes(Animal.cat.output.type)).toBe(true);
+    expect(animalTypes.includes(Animal.dog.output.type)).toBe(true);
+    expect(animalTypes.includes(Animal.snake.output.type)).toBe(true);
 })
 
 test('types (on empty variant)', () => {

--- a/src/variant.spec.ts
+++ b/src/variant.spec.ts
@@ -1,6 +1,4 @@
 import {fields, payload, scoped, TypeNames, variant, VariantOf, variation} from '.';
-import {GVariantOf, onTerms} from './generic';
-import {match} from './type';
 
 test('Simple module', () => {
     const Animal = variant({
@@ -13,7 +11,7 @@ test('Simple module', () => {
     })
     type Animal<T extends TypeNames<typeof Animal> = undefined> = VariantOf<typeof Animal, T>;
 
-    expect(Animal.cat.type).toBe('cat');
+    expect(Animal.cat.output.type).toBe('cat');
 })
 
 test('Renamed module', () => {
@@ -27,7 +25,7 @@ test('Renamed module', () => {
     }
     type Animal<T extends TypeNames<typeof Animal> = undefined> = VariantOf<typeof Animal, T>;
 
-    expect(Animal.cat.type).toBe('CAT');
+    expect(Animal.cat.output.type).toBe('CAT');
 })
 
 test('variant with variations', () => {
@@ -42,7 +40,7 @@ test('variant with variations', () => {
     type Animal<T extends TypeNames<typeof Animal> = undefined> = VariantOf<typeof Animal, T>;
 
     const snek = Animal.snake('Steve');
-    expect(Animal.cat.type).toBe('CAT');
+    expect(Animal.cat.output.type).toBe('CAT');
     expect(snek.name).toBe('Steve');
 })
 
@@ -58,8 +56,8 @@ test('variant with variations', () => {
     type Animal<T extends TypeNames<typeof Animal> = undefined> = VariantOf<typeof Animal, T>;
 
     const snek = Animal.snake('Steve');
-    expect(Animal.cat.type).toBe('cat');
-    expect(Animal.dog.type).toBe('DOG');
+    expect(Animal.cat.output.type).toBe('cat');
+    expect(Animal.dog.output.type).toBe('DOG');
     expect(snek.name).toBe('Steve');
 })
 
@@ -158,6 +156,6 @@ test('variant retains mismatched names', () => {
     const Animal3 = variant(Animal2);
 
     expect(Animal3.Cat).toBeDefined();
-    expect(Animal3.Cat.type).toBe('Animal/Cat');
-    expect(Animal3.Dog.type).toBe('Animal/Dog');
+    expect(Animal3.Cat.output.type).toBe('Animal/Cat');
+    expect(Animal3.Dog.output.type).toBe('Animal/Dog');
 })

--- a/src/variant.ts
+++ b/src/variant.ts
@@ -1,5 +1,5 @@
 import {GenericTemplate, GenericVariantRecord} from './generic';
-import {Func, Outputs, RawVariant, Variant, VariantCreator} from './precepts';
+import {Func, Outputs, RawVariant, VariantCreator} from './precepts';
 import {Identity, identityFunc, isPromise} from './util';
 
 /**
@@ -26,7 +26,7 @@ type CreatorFromListType<T extends ValidListType, K extends string> =
  * Create something that satisfies `VariantModule<K>` from some `VariantCreator`.
  */
 export type VMFromVC<T extends VariantCreator<string, Func, string>> = {
-    [P in T['type']]: Extract<T, Record<'type', P>>;
+    [P in T['output']['type']]: Extract<T, Record<'output', Record<'type', P>>>;
 }
 
 type CleanResult<T, U> = T extends undefined ? U : T extends Func ? T : T extends object ? U : T;
@@ -300,13 +300,13 @@ export function variantImpl<K extends string>(key: K): VariantFuncs<K> {
             }
         };
         Object.defineProperty(maker, 'name', {value: type, writable: false});
-        const outputs: Outputs<K, T> = {key, type};
+        const outputs: Outputs<K, T> = {output: {key, type}};
         return Object.assign(
             maker,
             outputs,
             {
                 [VARIANT_CREATOR_BRAND]: VARIANT_CREATOR_BRAND,
-                toString: function(this: Outputs<K, T>){return this.type}
+                toString: function(this: Outputs<K, T>){return this.output.type}
             }
         ) as VariantCreator<T, F extends VariantCreator<string, infer VF> ? VF : F, K>;
     }
@@ -339,7 +339,7 @@ export function variantImpl<K extends string>(key: K): VariantFuncs<K> {
             let creator = ((typeof t === 'string') ? variation(t) : t) as VariantCreator<string, Func, K>;
             return {
                 ...result,
-                [creator.type]: creator,
+                [creator.output.type]: creator,
             }
         }, {} as Identity<VMFromVC<CreatorFromListType<T, K>>>)
     }

--- a/src/variation.spec.ts
+++ b/src/variation.spec.ts
@@ -1,4 +1,4 @@
-import {isVariantCreator, scopeType, variantImpl} from './variant';
+import {isVariantCreator, variantImpl} from './variant';
 import {fields, payload} from './variant.tools';
 
 const str = {
@@ -90,8 +90,8 @@ test('variation .name', () => {
 test('variation outputs', () => {
     const yoc = variation('yo');
 
-    expect(yoc.key).toBe(DISCRIMINANT);
-    expect(yoc.type).toBe('yo');
+    expect(yoc.output.key).toBe(DISCRIMINANT);
+    expect(yoc.output.type).toBe('yo');
 })
 
 test('isVariantCreator', () => {
@@ -142,8 +142,8 @@ test('async variation output types', async () => {
 
     const result = AsyncTask();
 
-    expect(AsyncTask.type).toBe('A_TASK');
-    expect(AsyncTask.key).toBe('type');
+    expect(AsyncTask.output.type).toBe('A_TASK');
+    expect(AsyncTask.output.key).toBe('type');
 
     expect((result as any).four).toBeUndefined();
     expect((await result).four).toBe(4);


### PR DESCRIPTION
Finally got around to trying to tackle [the variant creator discriminant issue](https://github.com/paarthenon/variant/issues/46). Most of the changes are very straightforward, just moving accesses to `creator.type` to `creator.output.type`, but the changes to `match` are less so.